### PR TITLE
Support obtaining credentials from AWS IRSA

### DIFF
--- a/pkg/awsdiscovery/discovery_aws.go
+++ b/pkg/awsdiscovery/discovery_aws.go
@@ -31,7 +31,7 @@ func (d DiscoveryClientAWS) GetInstances() ([]discovery.Instance, error) {
 		Filters: d.filter(),
 	}
 	if ec2Client == nil {
-		awsSession := session.New()
+		awsSession := session.Must(session.NewSession())
 		awsConfig := &aws.Config{}
 		ec2Client = ec2.New(awsSession, awsConfig)
 	}


### PR DESCRIPTION
I wanted to provide credentials through Iam Role for Service Account but this is not working right now, fails with the following error
```
ERRO[0003] Failed to load ec2 instances                 
ERRO[0003] NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```
I figured the reason  is a deprecated call to create a new session. The following change makes IRSA work for me.
